### PR TITLE
Switch to cmake for build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ description = "FFI bindings for blosc-c"
 
 [features]
 lz4 = []
-zstd = []
+snappy = []
 zlib = []
+zstd = []
 
 [build-dependencies]
-cc = "1.0"
+cmake = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,55 +1,21 @@
-use std::fs;
-
-use cc::Build;
+fn define_bool(b: bool) -> &'static str {
+    if b {
+        "ON"
+    } else {
+        "OFF"
+    }
+}
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-
-    let mut build = cc::Build::new();
-
-    let target_mscv = cfg!(target_env = "msvc");
-    let add_file = |builder: &mut Build, folder: &str| {
-        for entry in fs::read_dir(folder).unwrap() {
-            let path = entry.unwrap().path();
-            if let Some(extension) = path.extension() {
-                if extension == "c" || extension == "cpp" || (!target_mscv && extension == "S") {
-                    builder.file(path);
-                }
-            }
-        }
-    };
-
-    add_file(&mut build, "c-blosc/blosc");
-
-    if cfg!(feature = "lz4") {
-        add_file(&mut build, "c-blosc/internal-complibs/lz4-1.9.3");
-        build.include("c-blosc/internal-complibs/lz4-1.9.3");
-        build.define("HAVE_LZ4", None);
-    }
-    if cfg!(feature = "zlib") {
-        add_file(&mut build, "c-blosc/internal-complibs/zlib-1.2.11");
-        build.include("c-blosc/internal-complibs/zlib-1.2.11");
-        build.define("HAVE_ZLIB", None);
-    }
-    if cfg!(feature = "zstd") {
-        add_file(&mut build, "c-blosc/internal-complibs/zstd-1.5.2/common");
-        add_file(&mut build, "c-blosc/internal-complibs/zstd-1.5.2/compress");
-        add_file(
-            &mut build,
-            "c-blosc/internal-complibs/zstd-1.5.2/decompress",
-        );
-        add_file(
-            &mut build,
-            "c-blosc/internal-complibs/zstd-1.5.2/dictBuilder",
-        );
-        build.include("c-blosc/internal-complibs/zstd-1.5.2");
-        build.define("HAVE_ZSTD", None);
-    }
-
-    let linklib = if cfg!(target_env = "msvc") {
-        "libblosc"
-    } else {
-        "blosc"
-    };
-    build.compile(linklib);
+    let mut config = cmake::Config::new("c-blosc");
+    config.define("DEACTIVATE_LZ4", define_bool(!cfg!(feature = "lz4")));
+    config.define("DEACTIVATE_SNAPPY", define_bool(!cfg!(feature = "snappy")));
+    config.define("DEACTIVATE_ZLIB", define_bool(!cfg!(feature = "zlib")));
+    config.define("DEACTIVATE_ZSTD", define_bool(!cfg!(feature = "zstd")));
+    let dst = config.build();
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib64", dst.display());
+    println!("cargo:rustc-link-lib=static=blosc");
 }

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,9 @@ fn define_bool(b: bool) -> &'static str {
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let mut config = cmake::Config::new("c-blosc");
+    config.define("BUILD_TESTS", "OFF");
+    config.define("BUILD_FUZZERS", "OFF");
+    config.define("BUILD_BENCHMARKS", "OFF");
     config.define("DEACTIVATE_LZ4", define_bool(!cfg!(feature = "lz4")));
     config.define("DEACTIVATE_SNAPPY", define_bool(!cfg!(feature = "snappy")));
     config.define("DEACTIVATE_ZLIB", define_bool(!cfg!(feature = "zlib")));


### PR DESCRIPTION
Replaces the `cc` build with a `cmake` based build and adds a new feature `snappy` to enable the snappy codec. This is a breaking change, as it requires `cmake` to be available.

This is needed for AVX/SSE2 support without reimplementing logic in the `c-blosc/CMakeLists.txt` in `build.rs`.
This patch speeds up the shuffling functions and gives me a substantial performance boost in my encoding/decoding benchmarks.

I've tested this on Ubuntu 22.04 and Windows.