### PR TITLE
Use -sys crates instead of bundled code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ exclude = [
     "c-blosc/compat/**",
     "c-blosc/tests/**",
     "c-blosc/bench/**",
-    "c-blosc/internal-complibs/zlib-1.2.13/**",
-    "c-blosc/internal-complibs/zstd-1.5.5/**",
-    "c-blosc/internal-complibs/lz4-1.9.4/**",
+    "c-blosc/internal-complibs/**",
 ]
 repository = "https://github.com/mulimoen/rust-blosc-src"
 keywords = ["compression"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ exclude = [
     "c-blosc/compat/**",
     "c-blosc/tests/**",
     "c-blosc/bench/**",
-    "c-blosc/internal-complibs/zlib-1.2.13/contrib/**",
-    "c-blosc/internal-complibs/zlib-1.2.13/examples/**",
-    "c-blosc/internal-complibs/zlib-1.2.13/doc/**",
+    "c-blosc/internal-complibs/zlib-1.2.13/**",
     "c-blosc/internal-complibs/zstd-1.5.5/legacy/**",
 ]
 repository = "https://github.com/mulimoen/rust-blosc-src"
@@ -23,7 +21,10 @@ description = "FFI bindings for blosc-c"
 [features]
 lz4 = []
 zstd = []
-zlib = []
+zlib = ["dep:libz-sys"]
 
 [build-dependencies]
 cc = "1.0"
+
+[dependencies]
+libz-sys = { version = "1.1.12", optional = true, default-features = false, features = ["static", "libc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
     "c-blosc/bench/**",
     "c-blosc/internal-complibs/zlib-1.2.13/**",
     "c-blosc/internal-complibs/zstd-1.5.5/**",
+    "c-blosc/internal-complibs/lz4-1.9.4/**",
 ]
 repository = "https://github.com/mulimoen/rust-blosc-src"
 keywords = ["compression"]
@@ -19,9 +20,9 @@ categories = ["external-ffi-bindings", "compression"]
 description = "FFI bindings for blosc-c"
 
 [features]
-lz4 = []
 zlib = ["dep:libz-sys"]
 zstd = ["dep:zstd-sys"]
+lz4 = ["dep:lz4-sys"]
 
 [build-dependencies]
 cc = "1.0"
@@ -29,3 +30,4 @@ cc = "1.0"
 [dependencies]
 libz-sys = { version = "1.1.12", optional = true, default-features = false, features = ["static", "libc"] }
 zstd-sys = { version = "2.0.9", optional = true }
+lz4-sys = { version = "1.9.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
     "c-blosc/tests/**",
     "c-blosc/bench/**",
     "c-blosc/internal-complibs/zlib-1.2.13/**",
-    "c-blosc/internal-complibs/zstd-1.5.5/legacy/**",
+    "c-blosc/internal-complibs/zstd-1.5.5/**",
 ]
 repository = "https://github.com/mulimoen/rust-blosc-src"
 keywords = ["compression"]
@@ -20,11 +20,12 @@ description = "FFI bindings for blosc-c"
 
 [features]
 lz4 = []
-zstd = []
 zlib = ["dep:libz-sys"]
+zstd = ["dep:zstd-sys"]
 
 [build-dependencies]
 cc = "1.0"
 
 [dependencies]
 libz-sys = { version = "1.1.12", optional = true, default-features = false, features = ["static", "libc"] }
+zstd-sys = { version = "2.0.9", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -52,17 +52,8 @@ fn main() {
     }
 
     if cfg!(feature = "zstd") {
-        add_file(&mut build, "c-blosc/internal-complibs/zstd-1.5.5/common");
-        add_file(&mut build, "c-blosc/internal-complibs/zstd-1.5.5/compress");
-        add_file(
-            &mut build,
-            "c-blosc/internal-complibs/zstd-1.5.5/decompress",
-        );
-        add_file(
-            &mut build,
-            "c-blosc/internal-complibs/zstd-1.5.5/dictBuilder",
-        );
-        build.include("c-blosc/internal-complibs/zstd-1.5.5");
+        let zstd_include_dir = std::env::var_os("DEP_ZSTD_INCLUDE").unwrap();
+        build.include(&zstd_include_dir);
         build.define("HAVE_ZSTD", None);
     }
 

--- a/build.rs
+++ b/build.rs
@@ -41,8 +41,8 @@ fn main() {
     }
 
     if cfg!(feature = "lz4") {
-        add_file(&mut build, "c-blosc/internal-complibs/lz4-1.9.4");
-        build.include("c-blosc/internal-complibs/lz4-1.9.4");
+        let lz4_include_dir = std::env::var_os("DEP_LZ4_INCLUDE").unwrap();
+        build.include(&lz4_include_dir);
         build.define("HAVE_LZ4", None);
     }
     if cfg!(feature = "zlib") {

--- a/build.rs
+++ b/build.rs
@@ -46,10 +46,11 @@ fn main() {
         build.define("HAVE_LZ4", None);
     }
     if cfg!(feature = "zlib") {
-        add_file(&mut build, "c-blosc/internal-complibs/zlib-1.2.13");
-        build.include("c-blosc/internal-complibs/zlib-1.2.13");
+        let zlib_include_dir = std::env::var_os("DEP_Z_INCLUDE").unwrap();
+        build.include(&zlib_include_dir);
         build.define("HAVE_ZLIB", None);
     }
+
     if cfg!(feature = "zstd") {
         add_file(&mut build, "c-blosc/internal-complibs/zstd-1.5.5/common");
         add_file(&mut build, "c-blosc/internal-complibs/zstd-1.5.5/compress");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,6 @@ include!("bindgen.rs");
 
 #[cfg(feature = "zlib")]
 extern crate libz_sys;
+
+#[cfg(feature = "zstd")]
+extern crate zstd_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,6 @@ extern crate libz_sys;
 
 #[cfg(feature = "zstd")]
 extern crate zstd_sys;
+
+#[cfg(feature = "lz4")]
+extern crate lz4_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,6 @@
 #![allow(non_camel_case_types)]
 
 include!("bindgen.rs");
+
+#[cfg(feature = "zlib")]
+extern crate libz_sys;


### PR DESCRIPTION
Fixes #9 

Breaking change as it involves linkage and new dependencies (`pkg-config`)