### PR TITLE
Add snappy codec support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blosc-src"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Magnus Ulimoen <magnus@ulimoen.dev>"]
 edition = "2021"
 build = "build.rs"
@@ -22,6 +22,7 @@ readme = "README.md"
 zlib = ["dep:libz-sys"]
 zstd = ["dep:zstd-sys"]
 lz4 = ["dep:lz4-sys"]
+snappy = ["dep:snappy_src"]
 
 [build-dependencies]
 cc = "1.0"
@@ -30,3 +31,4 @@ cc = "1.0"
 libz-sys = { version = "1.1.12", optional = true, default-features = false, features = ["static", "libc"] }
 zstd-sys = { version = "2.0.9", optional = true }
 lz4-sys = { version = "1.9.4", optional = true }
+snappy_src = { version = "0.2.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The crate builds `c-blosc` from source using the `cc` crate. As such it is requi
 * `zlib`
 * `zstd`
 * `lz4`
+* `snappy`
 
 When these are requested they will be built from source and available for use by `blosc`.
 

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,11 @@ fn main() {
         build.include(&zstd_include_dir);
         build.define("HAVE_ZSTD", None);
     }
+    if cfg!(feature = "snappy") {
+        let snappy_include_dir = std::env::var_os("DEP_SNAPPY_INCLUDE").unwrap();
+        build.include(&snappy_include_dir);
+        build.define("HAVE_SNAPPY", None);
+    }
 
     let linklib = if cfg!(target_env = "msvc") {
         "libblosc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,6 @@ extern crate zstd_sys;
 
 #[cfg(feature = "lz4")]
 extern crate lz4_sys;
+
+#[cfg(feature = "snappy")]
+extern crate snappy_src;


### PR DESCRIPTION
As you noticed in https://github.com/mulimoen/rust-blosc-src/issues/8, all of the snappy wrappers were out-of-date and unmaintained. This uses an [up-to-date snappy wrapper](https://github.com/LDeakin/rust_snappy_src) I've just created. I welcome a review of it.