### PR TITLE
Use gcc-15 fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "c-blosc"]
 	path = c-blosc
-	url = https://github.com/Blosc/c-blosc.git
+	url = https://github.com/GiGainfosystems/c-blosc.git


### PR DESCRIPTION
Backport fix for gcc 15

Replaces #17

@weiznich This uses your backported fork, so please don't delete this before an official version of c-blosc has been released