### PR TITLE
fix: revert MSRV back to 1.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "blosc-src"
 version = "0.3.5"
 authors = ["Magnus Ulimoen <magnus@ulimoen.dev>"]
 edition = "2021"
+rust-version = "1.64"
 build = "build.rs"
 links = "blosc"
 license-file = "c-blosc/LICENSE.txt"

--- a/bindgen.sh
+++ b/bindgen.sh
@@ -6,5 +6,6 @@ bindgen --no-rustfmt-bindings \
 	--allowlist-function '.*blosc.*' \
 	--allowlist-var '.*BLOSC.*' \
 	--clang-macro-fallback \
+    --rust-target 1.64 \
     c-blosc/blosc/blosc.h > src/bindgen.rs
 rustfmt src/bindgen.rs


### PR DESCRIPTION
The 0.3.x series has had an effective MSRV of 1.64 up until 0.3.5, which raised it to 1.82. This PR drops it back to 1.64 and sets the MSRV explicitly with the `rust-version` in the `Cargo.toml`.

If you get a release out with this patch, then [Rust-version aware dependency resolution](https://doc.rust-lang.org/nightly/cargo/reference/resolver.html#rust-version) can function, and you can more confidently raise the MSRV in the future if necessary. However, you might as well keep the MSRV low for this crate.