### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,19 @@ rust-version = "1.64"
 build = "build.rs"
 links = "blosc"
 license = "BSD-3-Clause"
-exclude = [
-    "c-blosc/compat/**",
-    "c-blosc/tests/**",
-    "c-blosc/bench/**",
-    "c-blosc/internal-complibs/**",
+include = [
+    "README.md",
+    "Cargo.toml",
+    "build.rs",
+    "src/**/*.rs",
+    "c-blosc/**/*.c",
+    "c-blosc/**/*.h",
+    "c-blosc/**/*.cpp",
+    "c-blocs/**/*.S",
+    "!c-blosc/compat/**",
+    "!c-blosc/tests/**",
+    "!c-blosc/bench/**",
+    "!c-blosc/internal-complibs/**",
 ]
 repository = "https://github.com/mulimoen/rust-blosc-src"
 keywords = ["compression"]


### PR DESCRIPTION
During a dependency review we noticed that the blosc-src crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.